### PR TITLE
GUI and SQL query rewrite to filter and order proposal submission gallery

### DIFF
--- a/apps/hs/qua-server/config/models
+++ b/apps/hs/qua-server/config/models
@@ -65,6 +65,18 @@ Scenario
     edxResultId   Text Maybe
     lastUpdate    UTCTime default=CURRENT_TIMESTAMP
 
+CurrentScenario
+    historyScenarioId ScenarioId
+    authorId      UserId
+    taskId        ScenarioProblemId
+    description   Text
+    edxResource   EdxResourceId
+    edxOutcomeUrl Text Maybe
+    edxResultId   Text Maybe
+    grade         Double Maybe
+    lastUpdate    UTCTime default=CURRENT_TIMESTAMP
+    SubmissionOf authorId taskId
+
 Review
     reviewerId  UserId
     scenarioId  ScenarioId
@@ -92,7 +104,7 @@ Criterion
 ProblemCriterion
     problemId ScenarioProblemId
     criterionId CriterionId
-    ProblemCriterionUnique problemId criterionId 
+    ProblemCriterionUnique problemId criterionId
 
 Vote
     voterId       UserId

--- a/apps/hs/qua-server/qua-server.cabal
+++ b/apps/hs/qua-server/qua-server.cabal
@@ -97,6 +97,7 @@ library
         Import
         Import.NoFoundation
         Import.Util
+        Import.BootstrapUtil
         Model
         Model.CustomTypes
         Model.Generated

--- a/apps/hs/qua-server/src/Handler/Mooc/SubmitProposal.hs
+++ b/apps/hs/qua-server/src/Handler/Mooc/SubmitProposal.hs
@@ -126,12 +126,25 @@ completelyNewOne img geometry desc = runMaybeT $ do
                                  <$> get scpId
                                  <*> getBy (EdxResLinkId resource_link_id edxCourseId)
     t <- liftIO getCurrentTime
-    lift . insert $ Scenario userId scpId
-                     img
-                     geometry
-                     desc
-                     (scenarioProblemScale scproblem)
-                     (entityKey edxres)
-                     lis_outcome_service_url
-                     lis_result_sourcedid
-                     t
+    let sc = Scenario
+               userId
+               scpId
+               img
+               geometry
+               desc
+               (scenarioProblemScale scproblem)
+               (entityKey edxres)
+               lis_outcome_service_url
+               lis_result_sourcedid
+               t
+    scId <- lift $ insert sc
+    _ <- lift $ insert $ CurrentScenario scId
+                           (scenarioAuthorId      sc)
+                           (scenarioTaskId        sc)
+                           (scenarioDescription   sc)
+                           (scenarioEdxResource   sc)
+                           (scenarioEdxOutcomeUrl sc)
+                           (scenarioEdxResultId   sc)
+                           Nothing
+                           (scenarioLastUpdate    sc)
+    return scId

--- a/apps/hs/qua-server/src/Import/BootstrapUtil.hs
+++ b/apps/hs/qua-server/src/Import/BootstrapUtil.hs
@@ -1,0 +1,20 @@
+module Import.BootstrapUtil where
+
+import Import
+
+bootstrapSelectFieldList :: (Eq a, RenderMessage site FormMessage)
+                         => [(Text, a)] -> Field (HandlerT site IO) a
+bootstrapSelectFieldList opts =
+    Field {
+      fieldParse   = parse
+    , fieldView    = viewFunc
+    , fieldEnctype = enc
+    }
+  where
+    (Field parse view enc) = selectFieldList opts
+    viewFunc id' name _attrs eitherText required = do
+        let select = view id' name [("class", "form-control")] eitherText required
+        [whamlet|
+          <div .form-group>
+            ^{select}
+        |]


### PR DESCRIPTION
The following SQL should work to make the migration:

    INSERT INTO current_scenario
      (history_scenario_id, author_id, task_id, description,
       edx_resource, edx_outcome_url, edx_result_id,
       last_update, grade)
    SELECT
      scenario.id, scenario.author_id, scenario.task_id, scenario.description,
      scenario.edx_resource, scenario.edx_outcome_url, scenario.edx_result_id,
      scenario.last_update, grade
    FROM scenario
    JOIN (
      SELECT scenario.author_id, scenario.task_id,
        MAX(scenario.last_update) as last_update,
        AVG(COALESCE(rating.value, 0)) as grade
      FROM scenario
      LEFT OUTER JOIN rating ON rating.author_id = scenario.author_id
      GROUP BY scenario.author_id, scenario.task_id
      ORDER BY scenario.task_id DESC, grade DESC, last_update DESC
    ) ns
    ON ns.author_id   = scenario.author_id AND
       ns.task_id     = scenario.task_id AND
       ns.last_update = scenario.last_update
    ;

    UPDATE current_scenario
    SET grade = NULL
    WHERE grade = 0
    ;

TODO:

- [ ] adjust grading algorithm code to write result into `currentScenarioGrade`.