### PR TITLE
Dynamically generate email from address

### DIFF
--- a/apps/hs/qua-server/src/Handler/Mooc/Admin/ReviewRequest.hs
+++ b/apps/hs/qua-server/src/Handler/Mooc/Admin/ReviewRequest.hs
@@ -134,9 +134,10 @@ Here is the full list of currently ungraded submissions:
 Thank you for your help!
                          |]
       $(logDebug) mailText
+      mailFrom <- appMailFrom
       liftIO $ Mail.renderSendMail $ Mail.simpleMail'
           (Mail.Address Nothing email) --to address
-          (Mail.Address (Just "ETH qua-kit") "noreply@qua-kit.ethz.ch") --from
+          mailFrom
           "Please help review the following submissions" --subject
             $ fromStrict mailText
     Nothing -> return ()


### PR DESCRIPTION
see #74

Note: we have several places where we assume the domains to be prefixed with `http://` and not `https://`. That's something we should fix. Can we assume its `https` in production and `http` otherwise... search for `drop 4` and `drop 7` to find those places...